### PR TITLE
#6 - Added basic PR template

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,0 +1,13 @@
+## Describe your changes
+
+## Issue ticket number and link
+
+## Checklist before requesting a review
+- [ ] I have performed a self-review of my code
+- [ ] If it is a core feature, I have added thorough tests.
+
+## How Has This Been Tested?
+<!--- Please describe in detail how you tested your changes. -->
+<!--- Include details of your testing environment, and the tests you ran to -->
+
+## Screenshots (if appropriate):

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -5,6 +5,7 @@
 ## Checklist before requesting a review
 - [ ] I have performed a self-review of my code
 - [ ] If it is a core feature, I have added thorough tests.
+- [ ] Documentation was updated/added (if needed)
 
 ## How Has This Been Tested?
 <!--- Please describe in detail how you tested your changes. -->


### PR DESCRIPTION
Closes #6 

Basic and simple PR template unabashedly stolen from parts of the internet.
Open for suggestions please!

Guide: https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository