### PR TITLE
Update bytemotion-node-ci.yml

### DIFF
--- a/.github/workflows/bytemotion-node-ci.yml
+++ b/.github/workflows/bytemotion-node-ci.yml
@@ -77,7 +77,7 @@ jobs:
 
       - name: Set PreRelease Release
         id: prerelease_release
-        if: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.merged == false }}
+        if: ${{ github.event_name == 'pull_request' && github.event.pull_request.merged == false }}
         run: |
           echo "RELEASE=prerelease" >> $GITHUB_OUTPUT 
           BRANCH=$(git rev-parse --abbrev-ref HEAD)


### PR DESCRIPTION
Remove `pull_request_target` from versioning

## Describe your changes
`pull_request_target` is used only for HEAD from master branch.
So we shouldn't use it in PR runs.

Still need to update rest of node-red repos for that...

## Issue ticket number and link
byte-motion/node-red-contrib-abb-robot#193

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Documentation was updated/added (if needed)

## How Has This Been Tested?
Well let's see what happens when CI machinery starts...

## Screenshots (if appropriate):